### PR TITLE
fix: PR description includes correct testing url by default

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 URL for testing:
 
-- https://{{ github.head_ref }}--lehre-site--berufsbildung-basel.aem.page/
+- https://{BRANCH_NAME}--lehre-site--berufsbildung-basel.aem.page/
 
 Issue:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
 URL for testing:
 
 - https://{{ github.head_ref }}--lehre-site--berufsbildung-basel.aem.page/
+
+Issue:

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -1,0 +1,25 @@
+name: Update PR Description
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  update-description:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const branchName = context.payload.pull_request.head.ref;
+            
+            if (body.includes('{BRANCH_NAME}')) {
+              const newBody = body.replace(/{BRANCH_NAME}/g, branchName);
+              
+              await github.rest.pulls.update({
+                ...context.repo,
+                pull_number: context.payload.pull_request.number,
+                body: newBody
+              });
+            }


### PR DESCRIPTION
Added github action to add correct testing url to bypass psi check

URL for testing:

- https://{{ github.head_ref }}--lehre-site--berufsbildung-basel.aem.page/

#72 